### PR TITLE
fix(commitlint): ignore dependabot commits

### DIFF
--- a/cmd-commitlint.config.mjs
+++ b/cmd-commitlint.config.mjs
@@ -13,4 +13,5 @@ export default {
     'body-leading-blank': [2, 'always'],
     'body-max-line-length': [2, 'always', 250]
   },
+  ignores: [(commit) => commit.startsWith('chore(deps):')],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "commitlint-config",
       "devDependencies": {
         "@commitlint/cli": "^18.0.0",
         "@commitlint/config-conventional": "^18.0.0"
@@ -613,9 +614,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2480,9 +2481,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",


### PR DESCRIPTION
Problem:
Dependabot creates commits with messages that are too long. There's no way to configure this for dependabot as far as I know.
Proposed solution:
Ignore all commit messages that start with `chore(deps):`.

Example of a failed build: https://github.com/fntsoftware/command/actions/runs/13005870958/job/36272579745

- [x] TODO: test

Tested according to readme. Format violations in commit messages that start with `chore(deps):` are no longer reported.